### PR TITLE
fix(docs): output ci task to build/html for GitHub Action

### DIFF
--- a/documentation/Taskfile.dist.yml
+++ b/documentation/Taskfile.dist.yml
@@ -19,7 +19,7 @@ tasks:
   ci:
     desc: Build HTML documentation and validate CDDL schema
     cmds:
-      - "{{.SPHINXBUILD}} -b html -W --keep-going {{.SOURCEDIR}} {{.BUILDDIR}}"
+      - "{{.SPHINXBUILD}} -b html -W --keep-going {{.SOURCEDIR}} {{.BUILDDIR}}/html"
       - task: linkcheck
       - task: validate-cddl
 


### PR DESCRIPTION
Fixes the GitHub Action upload-pages-artifact error by correcting the documentation build output path.

## Problem

The GitHub Action expects documentation at `documentation/build/html/`, but the `ci` task was outputting to `documentation/build/`.

This caused the error:
```
tar: documentation/build/html: Cannot open: No such file or directory
```

## Solution

Modified the `ci` task in `Taskfile.dist.yml` to output to `{{.BUILDDIR}}/html` to match:
- The `html` task output location
- GitHub Action expectations
- Standard Sphinx multi-builder output structure

## Verification

- ✅ Clean build succeeds: `task clean && task ci`
- ✅ Output verified at `build/html/`
- ✅ Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)